### PR TITLE
Update one_household_one_firm_with_logic

### DIFF
--- a/examples/one_household_one_firm_with_logic/firm.py
+++ b/examples/one_household_one_firm_with_logic/firm.py
@@ -10,7 +10,7 @@ class Firm(abce.Agent, abce.Firm):
         """
         self.create('money', 1000)
         self.mygood = "GOOD%i" % self.id  # GOOD1 if self.id == 1
-        self.set_cobb_douglas(self.mygood, 1, {"labor": 1})
+        self.create_cobb_douglas(self.mygood, 1, {"labor": 1})
         self.price = random.random() * 2
         self.inventory = 0
 

--- a/examples/one_household_one_firm_with_logic/start.py
+++ b/examples/one_household_one_firm_with_logic/start.py
@@ -6,7 +6,7 @@
     timeline.
 """
 
-from abcEconomics import Simulation, gui
+from abcEconomics import Simulation
 from firm import Firm
 from household import Household
 
@@ -15,13 +15,8 @@ parameters = {'name': '2x2',
               'rounds': 2500,
               'num_firms': 10}
 
-#@gui(parameters)
 def main(parameters):
     simulation = Simulation(processes=1)
-    simulation.declare_round_endowment(resource='adult',
-                                       units=1,
-                                       product='labor')
-    simulation.declare_perishable(good='labor')
 
     firms = simulation.build_agents(
         Firm, 'firm', number=parameters['num_firms'])
@@ -31,6 +26,7 @@ def main(parameters):
     try:
         for rnd in range(parameters['rounds']):
             simulation.advance_round(rnd)
+            households.refresh_services('labor', derived_from='adult', units=1)
             households.sell_labor()
             firms.buy_labor()
             firms.production()


### PR DESCRIPTION
This still have a remaining error
```
Traceback (most recent call last):
  File "start.py", line 48, in <module>
    main(parameters)
  File "start.py", line 23, in main
    households = simulation.build_agents(
  File "/home/rht/code/venv/lib/python3.8/site-packages/abcEconomics/__init__.py", line 311, in build_agents
    group.create_agents(AgentClass, agent_parameters=agent_parameters, **parameters)
  File "/home/rht/code/venv/lib/python3.8/site-packages/abcEconomics/group.py", line 209, in create_agents
    new_names = self._scheduler.add_agents(Agent, common_parameters, agent_parameters, self._agent_arguments, self.num_agents)
  File "/home/rht/code/venv/lib/python3.8/site-packages/abcEconomics/scheduler/singleprocess.py", line 38, in add_agents
    agent.init(**ChainMap(simulation_parameters, ap))
TypeError: init() got an unexpected keyword argument 'parameters'
```
@DavoudTaghawiNejad ?